### PR TITLE
Manage partnership proposal details

### DIFF
--- a/src/services/apis/groupProfileAPI.js
+++ b/src/services/apis/groupProfileAPI.js
@@ -41,6 +41,25 @@ export async function fetchGroupProfile(userId) {
   }
 }
 
+// 여러 학생단체 프로필을 ID 배열로 조회
+export async function fetchGroupProfilesByIds(ids) {
+  try {
+    if (!Array.isArray(ids) || ids.length === 0) return [];
+    const token = localStorage.getItem("accessToken");
+    const authAxios = getAuthAxios(token);
+    const results = await Promise.all(
+      ids.map(async (id) => {
+        const res = await authAxios.get(`/api/profiles/student-groups/${id}/`);
+        return res.data;
+      })
+    );
+    return results;
+  } catch (err) {
+    console.error("학생단체 프로필 배열 조회 실패:", err);
+    return [];
+  }
+}
+
 export function mappedOrg(user, idx) {
     const safeToStringCount = (val) => {
       if (typeof val === "number") return `${val.toLocaleString()}명`;
@@ -49,8 +68,8 @@ export function mappedOrg(user, idx) {
     };
 
     // // 시작일과 종료일 Date 객체로 변환 (있을 때만)
-    // const startDate = user?.partnership_start ? new Date(user.partnership_start) : null;
-    // const endDate = user?.partnership_end ? new Date(user.partnership_end) : null;
+    // const startDate = new Date(user?.partnership_start);
+    // const endDate = new Date(user?.partnership_end);
 
     // // // 개월 수 계산 (startDate와 endDate가 모두 있을 때만)
     // const period = startDate && endDate


### PR DESCRIPTION
Allow `OwnerSendSuggest` to display specific student group profiles by ID, enabling targeted viewing of student organizations.

The `OwnerSendSuggest` page now accepts an array of `groupIds` via `location.state`. If provided, it fetches these specific student group profiles and renders them in the `CardListGrid` with a 'home' card type, instead of the default sent proposals list. This provides flexibility to show curated lists of student organizations.

---
<a href="https://cursor.com/background-agent?bcId=bc-e090d06e-048a-499c-b55c-30a0f474513f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e090d06e-048a-499c-b55c-30a0f474513f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

